### PR TITLE
Replace getValues for plainValues

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -114,8 +114,12 @@ abstract class Enum implements \JsonSerializable
     /** Returns only the values of the constants
      * @return array
      */
-    public static function getValues(){
-        return \array_values(static::toArray());
+    public static function plainValues(){
+        $values = array();
+        foreach (static::toArray() as $key => $value) {
+            $values[] = $value;
+        }
+        return $values;
     }
 
     /**


### PR DESCRIPTION
plainValues is a new function for only return in a plain array with all the possible values of the enum